### PR TITLE
Don't check final comma in bib by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,16 +18,16 @@ Imports:
   crayon,
   utils,
 LazyData: TRUE
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Encoding: UTF-8
 Suggests: 
-  devtools,
-  ggplot2,
-  ggrepel,
-  jsonlite,
-  readr,
-  readxl,
-  rlang,
-  stringi,
-  testthat,
-  tinytex
+    devtools,
+    ggplot2,
+    ggrepel,
+    jsonlite,
+    readr,
+    readxl,
+    rlang,
+    stringi,
+    testthat (>= 2.1.0),
+    tinytex

--- a/R/checkGrattanReport.R
+++ b/R/checkGrattanReport.R
@@ -19,6 +19,7 @@
 #' set to the sole \code{.tex} file within \code{path}.
 #' @return Called for its side-effect.
 #' @param bib_warn_only If \code{TRUE}, show biber warnings as messages rather than errors.
+#' @param check_comma If \code{TRUE}, will check to see that each bib entry ends with a comma after its final field. If \code{FALSE} (the default), this check will not be performed.
 #' @export checkGrattanReport checkGrattanReports
 #' @import data.table
 #' @importFrom hutils if_else
@@ -59,7 +60,8 @@ checkGrattanReport <- function(path = ".",
                                rstudio = FALSE,
                                update_grattan.cls = pre_release,
                                filename = NULL,
-                               bib_warn_only = FALSE) {
+                               bib_warn_only = FALSE,
+                               check_comma = FALSE) {
   if (Sys.getenv("TRAVIS") == "true") {
     print(utils::packageVersion("grattanReporter"))
   }
@@ -372,7 +374,8 @@ checkGrattanReport <- function(path = ".",
         next
       }
     } else {
-      validate_bibliography(file = bib_file, rstudio = rstudio, .report_error = .report_error)
+      validate_bibliography(file = bib_file, rstudio = rstudio, .report_error = .report_error,
+                            check_comma = check_comma)
     }
     if (grepl("ropbox", full_bib_file, fixed = TRUE)) {
       cat("N: Not marking MD5 sum of valid file as the project",

--- a/R/validate_bibliography.R
+++ b/R/validate_bibliography.R
@@ -3,11 +3,14 @@
 #' @param file The bib file if specified.
 #' @param .report_error How errors should be reported.
 #' @param rstudio Use the RStudio API?
+#' @param check_comma Logical. If `TRUE`, an error will be given if each .bib entry 
+#' does not end with a comma. `FALSE` by default.
 #' @return \code{NULL} if bibliography validated.
 #' @export
 
 
-validate_bibliography <- function(path = ".", file = NULL, .report_error, rstudio = FALSE) {
+validate_bibliography <- function(path = ".", file = NULL, .report_error, rstudio = FALSE,
+                                  check_comma = FALSE) {
   
   if (missing(.report_error)){
     .report_error <- function(...) report2console(file = file, ..., rstudio = rstudio)
@@ -59,12 +62,14 @@ validate_bibliography <- function(path = ".", file = NULL, .report_error, rstudi
   bib <-
     bib[!grepl("% Valid", bib, fixed = TRUE)]
 
-  if (any(grepl(".[}]$", bib, perl = TRUE))){
-    line_no <- grep(".[}]$", bib, perl = TRUE)[[1]]
-    .report_error(line_no = line_no,
-                  context = bib[line_no],
-                  error_message = "Each field line in .bib must end with a comma (to allow reordering).")
-    stop("Each field line in .bib must end with a comma (to allow intra-entry reordering).")
+  if(isTRUE(check_comma)) {
+    if (any(grepl(".[}]$", bib, perl = TRUE))){
+      line_no <- grep(".[}]$", bib, perl = TRUE)[[1]]
+      .report_error(line_no = line_no,
+                    context = bib[line_no],
+                    error_message = "Each field line in .bib must end with a comma (to allow reordering).")
+      stop("Each field line in .bib must end with a comma (to allow intra-entry reordering).")
+    }
   }
 
   # Abbreviated names

--- a/man/checkGrattanReport.Rd
+++ b/man/checkGrattanReport.Rd
@@ -5,15 +5,33 @@
 \alias{checkGrattanReports}
 \title{Check Grattan Report}
 \usage{
-checkGrattanReport(path = ".", compile = FALSE, pre_release = FALSE,
-  release = FALSE, .proceed_after_rerun, .no_log = TRUE,
-  .log_psv = FALSE, embed = TRUE, rstudio = FALSE,
-  update_grattan.cls = pre_release, filename = NULL,
-  bib_warn_only = FALSE)
+checkGrattanReport(
+  path = ".",
+  compile = FALSE,
+  pre_release = FALSE,
+  release = FALSE,
+  .proceed_after_rerun,
+  .no_log = TRUE,
+  .log_psv = FALSE,
+  embed = TRUE,
+  rstudio = FALSE,
+  update_grattan.cls = pre_release,
+  filename = NULL,
+  bib_warn_only = FALSE,
+  check_comma = FALSE
+)
 
-checkGrattanReports(path = ".", compile = FALSE, pre_release = FALSE,
-  release = FALSE, .proceed_after_rerun, .no_log = TRUE,
-  embed = TRUE, rstudio = FALSE, update_grattan.cls = TRUE)
+checkGrattanReports(
+  path = ".",
+  compile = FALSE,
+  pre_release = FALSE,
+  release = FALSE,
+  .proceed_after_rerun,
+  .no_log = TRUE,
+  embed = TRUE,
+  rstudio = FALSE,
+  update_grattan.cls = TRUE
+)
 }
 \arguments{
 \item{path}{Path to search for the tex source file.}
@@ -44,6 +62,8 @@ Set to \code{FALSE} when checking the \code{grattex} repo itself. Also downloads
 set to the sole \code{.tex} file within \code{path}.}
 
 \item{bib_warn_only}{If \code{TRUE}, show biber warnings as messages rather than errors.}
+
+\item{check_comma}{If \code{TRUE}, will check to see that each bib entry ends with a comma after its final field. If \code{FALSE} (the default), this check will not be performed.}
 }
 \value{
 Called for its side-effect.

--- a/man/check_consecutive_words.Rd
+++ b/man/check_consecutive_words.Rd
@@ -4,8 +4,7 @@
 \alias{check_consecutive_words}
 \title{Check consecutive typeset words}
 \usage{
-check_consecutive_words(path = ".", latex_file = NULL,
-  md5sum.ok = NULL)
+check_consecutive_words(path = ".", latex_file = NULL, md5sum.ok = NULL)
 }
 \arguments{
 \item{path}{Path containing the latex file.}

--- a/man/check_preamble.Rd
+++ b/man/check_preamble.Rd
@@ -4,8 +4,7 @@
 \alias{check_preamble}
 \title{Check the preamble of a document}
 \usage{
-check_preamble(filename, .report_error, pre_release = FALSE,
-  release = FALSE)
+check_preamble(filename, .report_error, pre_release = FALSE, release = FALSE)
 }
 \arguments{
 \item{filename}{.tex file to check for errors}

--- a/man/correctly_spelled_words_fixed_txt.Rd
+++ b/man/correctly_spelled_words_fixed_txt.Rd
@@ -4,7 +4,9 @@
 \name{correctly_spelled_words_fixed_txt}
 \alias{correctly_spelled_words_fixed_txt}
 \title{List of correctly spelled words}
-\format{A character vector of words as fixed words to skip during the spell check.}
+\format{
+A character vector of words as fixed words to skip during the spell check.
+}
 \usage{
 correctly_spelled_words_fixed_txt
 }

--- a/man/grattan_CORRECTLY_SPELLED_WORDS_CASE_SENSITIVE.Rd
+++ b/man/grattan_CORRECTLY_SPELLED_WORDS_CASE_SENSITIVE.Rd
@@ -4,7 +4,9 @@
 \name{grattan_CORRECTLY_SPELLED_WORDS_CASE_SENSITIVE}
 \alias{grattan_CORRECTLY_SPELLED_WORDS_CASE_SENSITIVE}
 \title{List of correctly spelled, case-sensitive words}
-\format{A character vector of words as perl-regex case-sensitive patterns to skip during the spell check.}
+\format{
+A character vector of words as perl-regex case-sensitive patterns to skip during the spell check.
+}
 \usage{
 grattan_CORRECTLY_SPELLED_WORDS_CASE_SENSITIVE
 }

--- a/man/grattan_correctly_spelled_words.Rd
+++ b/man/grattan_correctly_spelled_words.Rd
@@ -4,7 +4,9 @@
 \name{grattan_correctly_spelled_words}
 \alias{grattan_correctly_spelled_words}
 \title{List of correctly spelled words}
-\format{A character vector of words as perl-regex patterns to skip during the spell check.}
+\format{
+A character vector of words as perl-regex patterns to skip during the spell check.
+}
 \usage{
 grattan_correctly_spelled_words
 }

--- a/man/replace_LaTeX_argument.Rd
+++ b/man/replace_LaTeX_argument.Rd
@@ -4,8 +4,12 @@
 \alias{replace_LaTeX_argument}
 \title{Replace contents of LaTeX argument}
 \usage{
-replace_LaTeX_argument(tex_lines, command_name, replacement,
-  .dummy_replacer = "ZzZz")
+replace_LaTeX_argument(
+  tex_lines,
+  command_name,
+  replacement,
+  .dummy_replacer = "ZzZz"
+)
 }
 \arguments{
 \item{tex_lines}{Lines of text (as from \code{readLines}).}

--- a/man/validate_bibliography.Rd
+++ b/man/validate_bibliography.Rd
@@ -4,8 +4,13 @@
 \alias{validate_bibliography}
 \title{Validate bibliography according Grattan style}
 \usage{
-validate_bibliography(path = ".", file = NULL, .report_error,
-  rstudio = FALSE)
+validate_bibliography(
+  path = ".",
+  file = NULL,
+  .report_error,
+  rstudio = FALSE,
+  check_comma = FALSE
+)
 }
 \arguments{
 \item{path}{Containing the bib file.}
@@ -15,6 +20,9 @@ validate_bibliography(path = ".", file = NULL, .report_error,
 \item{.report_error}{How errors should be reported.}
 
 \item{rstudio}{Use the RStudio API?}
+
+\item{check_comma}{Logical. If `TRUE`, an error will be given if each .bib entry 
+does not end with a comma. `FALSE` by default.}
 }
 \value{
 \code{NULL} if bibliography validated.

--- a/tests/testthat/test_validate_bibliography.R
+++ b/tests/testthat/test_validate_bibliography.R
@@ -36,3 +36,15 @@ test_that("Issue 75: Attorney-Generals", {
                regexp = "Attorney")
 })
 
+test_that("Absence of final comma throws error when appropriate", {
+  no_comma_bib <- "./validate-bib/no-comma.bib"
+  expect_null(validate_bibliography(file = no_comma_bib))
+  expect_null(validate_bibliography(file = no_comma_bib, check_comma = FALSE))
+  expect_error(validate_bibliography(file = no_comma_bib, check_comma = TRUE))
+  
+  comma_bib <-  "./validate-bib/has-comma.bib"
+  expect_null(validate_bibliography(file = comma_bib))
+  expect_null(validate_bibliography(file = comma_bib, check_comma = FALSE))
+  expect_null(validate_bibliography(file = comma_bib, check_comma = TRUE))
+})
+

--- a/tests/testthat/validate-bib/has-comma.bib
+++ b/tests/testthat/validate-bib/has-comma.bib
@@ -1,0 +1,7 @@
+@TechReport{caresales-tank-2020,
+  author       = {David McCowen},
+  title        = {Australian car sales down \$30 million per day},
+  date         = {2020-04-06},
+  institution  = {News.com.au},
+  url          = {https://www.news.com.au/technology/innovation/motoring/motoring-news/australian-car-sales-down-30-million-per-day/news-story/44562b748275526296af10232bd36ebf},
+}

--- a/tests/testthat/validate-bib/no-comma.bib
+++ b/tests/testthat/validate-bib/no-comma.bib
@@ -1,0 +1,7 @@
+@TechReport{caresales-tank-2020,
+  author       = {David McCowen},
+  title        = {Australian car sales down \$30 million per day},
+  date         = {2020-04-06},
+  institution  = {News.com.au},
+  url          = {https://www.news.com.au/technology/innovation/motoring/motoring-news/australian-car-sales-down-30-million-per-day/news-story/44562b748275526296af10232bd36ebf}
+}


### PR DESCRIPTION
by default, `checkGrattanReport()` no longer checks to ensure that the final field in each bib entry has a comma.

The old behaviour is available by running `checkGrattanReport(check_comma = TRUE)`